### PR TITLE
Include the package pkg-config on role.

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -44,6 +44,7 @@
     - nmon
     - openssh-server
     - patch
+    - pkg-config
     - postgresql
     - postgresql
     - postgresql-client


### PR DESCRIPTION
This necessary for the correct installation of many galaxy tools and it is also listed in the page https://wiki.galaxyproject.org/Admin/Config/ToolDependenciesList page as a required package.
