### PR TITLE
* Make slurm package optional, dependent on galaxy_slurm_drm var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,6 @@ postgres_user_gid: 121
 
 configure_docker: yes
 docker_package: docker-engine
+
+# install packages to interface with SLURM DRM
+galaxy_slurm_drm: true

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -60,7 +60,6 @@
     - python-virtualenv
     - python-pip
     - rsync
-    - slurm-drmaa-dev
     - supervisor
     - swig
     - sysstat
@@ -68,6 +67,10 @@
     - vim
     - wget
     - zlib1g-dev
+
+- name: Add slurm DRMAA package
+  apt: pkg=slurm-drmaa-dev state={{ apt_package_state }}
+  when: galaxy_slurm_drm
 
 - name: Install required system packages - release_specific
   apt: pkg={{ item }} state={{ apt_package_state }}


### PR DESCRIPTION
Split out the SLURM DRMAA lib requirement, made its installation dependent on galaxy_slurm_drm var which is, by default, true.
