### PR TITLE
Move docker to transient storage and pin nginx PPA

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ postgres_user_gid: 121
 configure_docker: yes
 install_apparmor: yes
 docker_package: docker-engine
+docker_storage_location: /var/lib/docker

--- a/files/galaxyproject-nginx-pin-600
+++ b/files/galaxyproject-nginx-pin-600
@@ -1,0 +1,3 @@
+Package:  *
+Pin: release o=LP-PPA-galaxyproject-nginx
+Pin-Priority: 600

--- a/files/m-vandenbeek-nginx-upload-store-pin-600
+++ b/files/m-vandenbeek-nginx-upload-store-pin-600
@@ -1,0 +1,3 @@
+Package:  *
+Pin: release o=LP-PPA-m-vandenbeek-nginx-upload-store
+Pin-Priority: 600

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -17,5 +17,14 @@
 - name: Add Galaxy user to docker group - allowing sudoless docker usage
   user: name={{ galaxy_user_name }} groups=docker append=yes
 
+- name: Stop Docker service
+  service: name=docker state=stopped
+  
 - name: Set DOCKER_OPTS
   lineinfile: dest=/etc/default/docker line='DOCKER_OPTS="--storage-driver=devicemapper -g /mnt/docker"'
+
+- name: Remove old Docker folder
+  file: path=/var/lib/docker state=absent
+  
+- name: Restart the Docker service
+  service: name=docker state=started

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -21,7 +21,7 @@
   service: name=docker state=stopped
   
 - name: Set DOCKER_OPTS
-  lineinfile: dest=/etc/default/docker line='DOCKER_OPTS="--storage-driver=devicemapper -g /mnt/docker"'
+  lineinfile: dest=/etc/default/docker line='DOCKER_OPTS="--storage-driver=devicemapper -g {{ docker_storage_location }}"'
 
 - name: Remove old Docker folder
   file: path=/var/lib/docker state=absent

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -4,8 +4,16 @@
   apt_repository: repo="ppa:galaxyproject/nginx" update_cache=no
   when: ansible_distribution_version <= "15.04"
 
+- name: Pin Galaxy's versions of the PPAs so they take priority over the defaults
+  copy: src=galaxyproject-nginx-pin-600 dest=/etc/apt/preferences.d/galaxyproject-nginx-pin-600
+  when: ansible_distribution_version <= "15.04"
+
 - name: Add custom Galaxy PPA (used for nginx package)
   apt_repository: repo="ppa:m-vandenbeek/nginx-upload-store" update_cache=no
+  when: ansible_distribution_version > "15.04"
+
+- name: Pin Galaxy's versions of the PPAs so they take priority over the defaults
+  copy: src=m-vandenbeek-nginx-upload-store-pin-600 dest=/etc/apt/preferences.d/m-vandenbeek-nginx-upload-store-pin-600
   when: ansible_distribution_version > "15.04"
 
 - name: Add Docker repository key

--- a/tasks/system_users.yml
+++ b/tasks/system_users.yml
@@ -19,7 +19,7 @@
   when: configure_docker
 
 - name: Set DOCKER_OPTS
-  lineinfile: dest=/etc/default/docker line='DOCKER_OPTS="--storage-driver=devicemapper"'
+  lineinfile: dest=/etc/default/docker line='DOCKER_OPTS="--storage-driver=devicemapper -g /mnt/docker"'
   when: configure_docker
 
 - name: Add nobody user to shadow group


### PR DESCRIPTION
This pull moves Docker's /var/lib/Docker folder to transient storage, saving around 1.7GB of space in the root partition. In addition, this increases the priority of the Galaxy PPA for nginx so that newer default versions don't supersede the Galaxy version of nginx.
