### PR TITLE
Add rabbitmq installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,5 +26,6 @@ postgres_user_gid: 121
 
 configure_docker: yes
 install_apparmor: yes
+install_rabbitmq: no
 docker_package: docker-engine
 docker_storage_location: /var/lib/docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,9 @@
 - include: ubuntu/packages.yml
   when: install_packages and ansible_distribution == 'Ubuntu'
 
+- include: ubuntu/rabbitmq.yml
+  when: install_rabbitmq  # Works on Ubunta and Debian
+
 - include: ubuntu/docker.yml
   when: configure_docker and ansible_distribution == 'Ubuntu'
 

--- a/tasks/ubuntu/rabbitmq.yml
+++ b/tasks/ubuntu/rabbitmq.yml
@@ -1,0 +1,11 @@
+- name: Add key for rabbitmq apt repository
+  apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc state=present
+
+- name: Add rabbitmq official apt repository
+  apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' state=present
+
+- name: Install rabbitmq-server
+  apt: pkg=rabbitmq-server state={{ apt_package_state }} install_recommends=yes
+
+- name: Stop rabbitmq server
+  service: name=rabbitmq-server state=stopped enabled=no


### PR DESCRIPTION
There are currently some limitations in how galaxy does interprocess communication (e.g if a job handler sends a control_task, these never appear in uwsgi web processes). This works when using amqp instead of the default sqlalchemy transport. When using amqp, one thing of immediate benefit is that data manager jobs in multi-handler setups can trigger reloading data tables across all handlers when rabbitmq is installed and configured. So this adds the rabbitmq installation part, and I'll add a PR to ansible-galaxy-extras to have supervisor control rabbitmq.
