### PR TITLE
pin postgresql versions 

### DIFF
--- a/tasks/ubuntu/packages.yml
+++ b/tasks/ubuntu/packages.yml
@@ -50,9 +50,6 @@
     - openssh-server
     - patch
     - pkg-config
-    - postgresql
-    - postgresql
-    - postgresql-client
     - python-boto
     - python-dev
     - python-prettytable
@@ -86,6 +83,8 @@
 - name: Install required system packages - release_specific
   apt: pkg={{ item }} state={{ apt_package_state }}
   with_items:
+    - postgresql-9.3
+    - postgresql-client-9.3
     - postgresql-plpython-9.3
     - postgresql-server-dev-9.3
   when: ansible_distribution_version <= "15.04"
@@ -93,6 +92,8 @@
 - name: Install required system packages - 15.10
   apt: pkg={{ item }} state={{ apt_package_state }}
   with_items:
+    - postgresql-9.4
+    - postgresql-client-9.4
     - postgresql-plpython-9.4
     - postgresql-server-dev-9.4
     - virtualenv
@@ -101,6 +102,8 @@
 - name: Install required system packages - 16.04
   apt: pkg={{ item }} state={{ apt_package_state }}
   with_items:
+    - postgresql-9.5
+    - postgresql-client-9.5
     - postgresql-plpython-9.5
     - postgresql-server-dev-9.5
     - virtualenv


### PR DESCRIPTION
In its current state, the role install postgresql without a version number. Although postgres will be installed and it will be the correct version, client cannot connect to postgresql on port 5432 in various occasion. It a packaging issue discussed in https://askubuntu.com/questions/50621/cannot-connect-to-postgresql-on-port-5432

In this PR, postgresql 9.3, 9.4 and 9.5 are pinned for ubuntu 14.04, 15.10 and 16.04, respectively. The code change also fixes a repetition of postgresql in apt-install list. It is also possible that the code change makes the ensure_postgresql_up optional, although I did not tested it