### PR TITLE
RedHat support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ services:
  - docker
 
 env:
-  - FILENAME=Dockerfile.ubuntu
+  - FILENAME=Dockerfile.centos
   - FILENAME=Dockerfile.debian
+  - FILENAME=Dockerfile.ubuntu
 
 script:
   - docker build -t ansible-galaxy-os -f $FILENAME .

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,12 @@
+FROM centos:7
+
+RUN yum -y -q -e 0 update
+RUN yum -y -q -e 0 install ansible
+
+RUN mkdir /tmp/ansible
+WORKDIR /tmp/ansible
+ADD local.yml /tmp/ansible/local.yml
+ADD defaults /tmp/ansible/defaults
+ADD tasks /tmp/ansible/tasks
+
+RUN ansible-playbook -i localhost, local.yml -e "@defaults/main.yml"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,6 +2,10 @@ FROM debian:8
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" >> /etc/apt/sources.list
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+
 RUN apt-get -qq update && apt-get install -qq apt-utils apt-transport-https \
  && apt-get install -qq -y ansible \
  && apt-get autoremove \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ given part of the role should be executed:
  - `install_maintainance_packages`: (default: `yes`) install convenience system
     packages used for server maintenance and administration
  - `configure_docker`: (default: `yes`) configure Docker as part of `install_packages`
- - `apt_package_state`: (default: `latest`) set to `present` to not force update
+ - `package_state`: (default: `latest`) set to `present` to not force update
     of existing installed packages.
  - `add_system_users`: (default: `yes`) configure system level users
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ install_packages: yes
 # If install_packages is 'yes', following determines if they are updated
 # ('latest') or left alone ('present') if they are already installed but
 # not updated.
-apt_package_state: latest
+package_state: latest
 install_maintainance_packages: yes
 add_system_users: yes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,11 +18,13 @@ add_system_users: yes
 galaxy_user_name: galaxy
 galaxy_user_uid: 1001
 galaxy_user_gid: 1001
+galaxy_user_home: /home/{{ galaxy_user_name }}
+galaxy_user_shell: /bin/bash
 
 postgres_user_name: postgres
-postgres_user_home: /var/lib/postgresql
 postgres_user_uid: 211
 postgres_user_gid: 221
+postgres_user_home: /var/lib/postgresql
 
 configure_docker: yes
 install_apparmor: yes

--- a/tasks/debian/docker.yml
+++ b/tasks/debian/docker.yml
@@ -1,11 +1,11 @@
 - name: Install Docker package
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
+  apt: pkg={{ item }} state={{ package_state }} install_recommends=no
   with_items:
     - "{{ docker_package }}"
   when: install_packages
 
 - name: Install apparmor
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
    - apparmor
    - cgroup-bin

--- a/tasks/debian/packages.yml
+++ b/tasks/debian/packages.yml
@@ -1,6 +1,6 @@
 ---
 - name: Prerequisites
-  apt: name={{ item }} state={{ apt_package_state }} update_cache=yes
+  apt: name={{ item }} state={{ package_state }} update_cache=yes
   with_items:
     - apt-utils
     - apt-transport-https
@@ -18,7 +18,7 @@
   apt: update_cache=yes
 
 - name: Install required system packages
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
+  apt: pkg={{ item }} state={{ package_state }} install_recommends=no
   with_items:
     - ant
     - cmake
@@ -60,7 +60,7 @@
     - zlib1g-dev
 
 - name: Install packages for system maintenance
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - atop
     - bioperl
@@ -74,7 +74,7 @@
   when: install_maintainance_packages
 
 - name: Install required system packages - 8
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - postgresql-plpython-9.4
     - postgresql-server-dev-9.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,24 @@
 ---
 # Install the base operating system requirements for running Galaxy
 
-- include: system_users.yml
+- include_tasks: system_users.yml
   when: add_system_users
 
-- include: ubuntu/packages.yml
+- include_tasks: ubuntu/packages.yml
   when: install_packages and ansible_distribution == 'Ubuntu'
 
-- include: ubuntu/rabbitmq.yml
-  when: install_rabbitmq  # Works on Ubunta and Debian
+- include_tasks: ubuntu/rabbitmq.yml
+  when: install_rabbitmq and ansible_os_familty == 'Debian'
 
-- include: ubuntu/docker.yml
+- include_tasks: ubuntu/docker.yml
   when: configure_docker and ansible_distribution == 'Ubuntu'
 
-- include: debian/packages.yml
+- include_tasks: debian/packages.yml
   when: install_packages and ansible_distribution == 'Debian'
 
-- include: debian/docker.yml
+- include_tasks: debian/docker.yml
   when: configure_docker and ansible_distribution == 'Debian'
+
+- include_tasks: redhat/packages.yml
+  when: install_packages and ansible_os_family == 'RedHat'
+

--- a/tasks/redhat/packages.yml
+++ b/tasks/redhat/packages.yml
@@ -1,0 +1,76 @@
+---
+- name: Prerequisites
+  yum:
+    name: "{{ packages }}"
+    state: "{{ package_state }}"
+  vars:
+    packages:
+      - epel-release
+      - ca-certificates
+
+- name: Update yum cache
+  yum:
+    name: '*'
+    update_cache: yes
+
+- name: Install required system packages
+  yum:
+    name: "{{ packages }}"
+    state: "{{ package_state }}"
+  vars:
+    packages:
+      - ant
+      - cmake
+      - curl
+      - gcc-c++
+      - gcc
+      - gcc-gfortran
+      - git
+      - libffi-devel
+      - lapack-devel
+      - ncurses-devel
+      - openblas-devel
+      - pam-devel
+      - postgresql-plpython
+      - postgresql-devel
+      - postgresql-devel
+      - make
+      - mercurial
+      - git
+      - nginx
+      - openssh-server
+      - patch
+      - pkgconfig
+      - postgresql-server
+      - postgresql
+      - python-devel
+      - python-boto
+      - python-prettytable
+      - python-psycopg2
+      - python-virtualenv
+      - python-pip
+      - rsync
+      - samtools
+      - sudo
+      - supervisor
+      - swig
+      - sysstat
+      - unzip
+      - wget
+      - zlib-devel
+
+- name: Install packages for system maintenance
+  yum:
+    name: "{{ packages }}"
+    state: "{{ package_state }}"
+  vars:
+    packages:
+      - atop
+      - ipython
+      - iotop
+      - htop
+      - iftop
+      - nmon
+      - axel
+      - vim
+  when: install_maintainance_packages

--- a/tasks/system_users.yml
+++ b/tasks/system_users.yml
@@ -7,17 +7,18 @@
     - { name: "{{ galaxy_user_name }}", gid: "{{ galaxy_user_gid }}" }
     - { name: "{{ postgres_user_name}}", gid: "{{ postgres_user_gid }}" }
 
-- name: Add shadow groups
-  group: name=shadow system=yes
-
 - name: Add postgres user
-  user: name={{ postgres_user_name }} uid={{ postgres_user_uid }} system=yes home={{ postgres_user_home }}
+  user:
+    name: "{{ postgres_user_name }}"
+    uid: "{{ postgres_user_uid }}"
+    group: "{{ postgres_user_gid }}"
+    home: "{{ postgres_user_home }}"
+    system: yes
 
-- name: Adjust postgresql permissions
-  file: path={{ postgres_user_home }} group={{ postgres_user_name }} owner={{ postgres_user_name }} recurse=yes
- 
 - name: Add galaxy user
-  user: name={{ galaxy_user_name }} uid={{ galaxy_user_uid }} shell=/bin/bash groups={{ galaxy_user_name }},shadow
-
-- name: Add nobody user to shadow group
-  user: name=nobody groups=shadow
+  user:
+    name: "{{ galaxy_user_name }}"
+    uid: "{{ galaxy_user_uid }}"
+    group: "{{ galaxy_user_gid }}"
+    home: "{{ galaxy_user_home }}"
+    shell: "{{ galaxy_user_shell }}"

--- a/tasks/system_users.yml
+++ b/tasks/system_users.yml
@@ -5,7 +5,7 @@
   group: name={{ item.name }} gid={{ item.gid }}  system=yes
   with_items:
     - { name: "{{ galaxy_user_name }}", gid: "{{ galaxy_user_gid }}" }
-    - { name: "{{postgres_user_name}}", gid: "{{ postgres_user_gid }}" }
+    - { name: "{{ postgres_user_name}}", gid: "{{ postgres_user_gid }}" }
 
 - name: Add shadow groups
   group: name=shadow system=yes

--- a/tasks/ubuntu/docker.yml
+++ b/tasks/ubuntu/docker.yml
@@ -1,11 +1,11 @@
 - name: Install Docker package
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
+  apt: pkg={{ item }} state={{ package_state }} install_recommends=no
   with_items:
     - "{{ docker_package }}"
   when: install_packages
 
 - name: Install apparmor
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
    - apparmor
    - cgroup-lite

--- a/tasks/ubuntu/packages.yml
+++ b/tasks/ubuntu/packages.yml
@@ -28,7 +28,7 @@
   apt: update_cache=yes
 
 - name: Install required system packages
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
+  apt: pkg={{ item }} state={{ package_state }} install_recommends=no
   with_items:
     - ant
     - cmake
@@ -67,7 +67,7 @@
     - zlib1g-dev
 
 - name: Install packages for system maintenance
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - atop
     - bioperl
@@ -81,7 +81,7 @@
   when: install_maintainance_packages
 
 - name: Install required system packages - release_specific
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - postgresql-9.3
     - postgresql-client-9.3
@@ -90,7 +90,7 @@
   when: ansible_distribution_version <= "15.04"
 
 - name: Install required system packages - 15.10
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - postgresql-9.4
     - postgresql-client-9.4
@@ -100,7 +100,7 @@
   when: ansible_distribution_version == "15.10"
 
 - name: Install required system packages - 16.04
-  apt: pkg={{ item }} state={{ apt_package_state }}
+  apt: pkg={{ item }} state={{ package_state }}
   with_items:
     - postgresql-9.5
     - postgresql-client-9.5

--- a/tasks/ubuntu/rabbitmq.yml
+++ b/tasks/ubuntu/rabbitmq.yml
@@ -5,7 +5,7 @@
   apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' state=present
 
 - name: Install rabbitmq-server
-  apt: pkg=rabbitmq-server state={{ apt_package_state }} install_recommends=yes
+  apt: pkg=rabbitmq-server state={{ package_state }} install_recommends=yes
 
 - name: Stop rabbitmq server
   service: name=rabbitmq-server state=stopped enabled=no


### PR DESCRIPTION
Support for RedHat family (CentOS 7.5 tested).

Renamed the `apt_package_state` variable to `package_state`.

As many yum equivalent packages were added for each apt counterpart found in `tasks/debian/packages.yml` . Packages which were not found or do not exist are:
  - `libparsehash-dev`
  - `slurm-drmaa-dev`
  - `bioperl`
 
Additionally, the yum equivalents of `postgreseql-plpython` and `postgresql-server-dev` use version `9.2` instead of `9.4`, as that is the available version.

Updated `tasks/main.yml`'s deprecated `include` statements to `include_tasks`.