### PR TITLE
Upgrade deprecated syntax (apt/loop)

### DIFF
--- a/tasks/debian/docker.yml
+++ b/tasks/debian/docker.yml
@@ -1,14 +1,17 @@
 - name: Install Docker package
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
-  with_items:
-    - "{{ docker_package }}"
+  apt:
+    pkg: "{{ docker_package }}"
+    state: "{{ apt_package_state }}"
+    install_recommends: no
   when: install_packages
 
 - name: Install apparmor
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-   - apparmor
-   - cgroup-bin
+  apt:
+    pkg: [
+      'apparmor',
+      'cgroup-bin'
+    ]
+    state: "{{ apt_package_state }}"
   when: install_apparmor
 
 - name: Allow galaxy user to run docker with sudo

--- a/tasks/debian/packages.yml
+++ b/tasks/debian/packages.yml
@@ -1,82 +1,92 @@
 ---
 - name: Prerequisites
-  apt: name={{ item }} state={{ apt_package_state }} update_cache=yes
-  with_items:
-    - apt-utils
-    - apt-transport-https
-    - ca-certificates
+  apt: 
+    pkg: [
+      'apt-utils',
+      'apt-transport-https',
+      'ca-certificates'
+    ]
+    state: "{{ apt_package_state }}"
+    update_cache: yes
 
 - name: Add Docker repository key
   apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D
   when: configure_docker
 
 - name: Add Docker repository
-  apt_repository: repo='deb https://apt.dockerproject.org/repo debian-{{ ansible_distribution_release }} main' update_cache=no #'
+  apt_repository: repo="deb https://apt.dockerproject.org/repo debian-{{ ansible_distribution_release }} main" update_cache=no
   when: configure_docker
 
 - name: Update APT cache
   apt: update_cache=yes
 
 - name: Install required system packages
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
-  with_items:
-    - ant
-    - cmake
-    - curl
-    - g++
-    - gcc
-    - gfortran
-    - git
-    - libffi-dev
-    - liblapack-dev
-    - libncurses5-dev
-    - libopenblas-dev
-    - libpam0g-dev
-    - libpq-dev
-    - libsparsehash-dev
-    - make
-    - mercurial
-    - nginx-extras
-    - openssh-server
-    - patch
-    - pkg-config
-    - postgresql
-    - postgresql-client
-    - python-boto
-    - python-dev
-    - python-prettytable
-    - python-psycopg2
-    - python-virtualenv
-    - python-pip
-    - rsync
-    - samtools
-    - slurm-drmaa-dev
-    - sudo
-    - supervisor
-    - swig
-    - sysstat
-    - unzip
-    - wget
-    - zlib1g-dev
+  apt: 
+    pkg: [
+      'ant',
+      'cmake',
+      'curl',
+      'g++',
+      'gcc',
+      'gfortran',
+      'git',
+      'libffi-dev',
+      'liblapack-dev',
+      'libncurses5-dev',
+      'libopenblas-dev',
+      'libpam0g-dev',
+      'libpq-dev',
+      'libsparsehash-dev',
+      'make',
+      'mercurial',
+      'nginx-extras',
+      'openssh-server',
+      'patch',
+      'pkg-config',
+      'postgresql',
+      'postgresql-client',
+      'python-boto',
+      'python-dev',
+      'python-prettytable',
+      'python-psycopg2',
+      'python-virtualenv',
+      'python-pip',
+      'rsync',
+      'samtools',
+      'slurm-drmaa-dev',
+      'sudo',
+      'supervisor',
+      'swig',
+      'sysstat',
+      'unzip',
+      'wget',
+      'zlib1g-dev'
+    ]
+    state: "{{ apt_package_state }}"
+    install_recommends: no
 
 - name: Install packages for system maintenance
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - atop
-    - bioperl
-    - ipython
-    - iotop
-    - htop
-    - iftop
-    - nmon
-    - axel
-    - vim
+  apt: 
+    pkg: [
+      'atop',
+      'bioperl',
+      'ipython',
+      'iotop',
+      'htop',
+      'iftop',
+      'nmon',
+      'axel',
+      'vim'
+    ]
+    state: "{{ apt_package_state }}"
   when: install_maintainance_packages
 
 - name: Install required system packages - 8
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - postgresql-plpython-9.4
-    - postgresql-server-dev-9.4
-    - virtualenv
+  apt: 
+    pkg: [
+      'postgresql-plpython-9.4',
+      'postgresql-server-dev-9.4',
+      'virtualenv'
+    ]
+    state: "{{ apt_package_state }}"
   when: ansible_distribution_version >= 8

--- a/tasks/ubuntu/docker.yml
+++ b/tasks/ubuntu/docker.yml
@@ -1,14 +1,17 @@
 - name: Install Docker package
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
-  with_items:
-    - "{{ docker_package }}"
+  apt:
+    pkg: "{{ docker_package }}"
+    state: "{{ apt_package_state }}"
+    install_recommends: no
   when: install_packages
 
 - name: Install apparmor
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-   - apparmor
-   - cgroup-lite
+  apt:
+    pkg: [
+      'apparmor',
+      'cgroup-lite'
+    ]
+    state: "{{ apt_package_state }}"
   when: install_apparmor
 
 - name: Allow galaxy user to run docker with sudo

--- a/tasks/ubuntu/packages.yml
+++ b/tasks/ubuntu/packages.yml
@@ -21,90 +21,101 @@
   when: configure_docker
 
 - name: Add Docker repository
-  apt_repository: repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main' update_cache=no #'
+  apt_repository: repo="deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main" update_cache=no
   when: configure_docker
 
 - name: Update APT cache
   apt: update_cache=yes
 
 - name: Install required system packages
-  apt: pkg={{ item }} state={{ apt_package_state }} install_recommends=no
-  with_items:
-    - ant
-    - cmake
-    - curl
-    - g++
-    - gcc
-    - gfortran
-    - git-core
-    - libffi-dev
-    - liblapack-dev
-    - libncurses5-dev
-    - libopenblas-dev
-    - libpam0g-dev
-    - libpq-dev
-    - libsparsehash-dev
-    - make
-    - mercurial
-    - nginx-extras
-    - openssh-server
-    - patch
-    - pkg-config
-    - python-boto
-    - python-dev
-    - python-prettytable
-    - python-psycopg2
-    - python-virtualenv
-    - python-pip
-    - rsync
-    - samtools
-    - slurm-drmaa-dev
-    - supervisor
-    - swig
-    - sysstat
-    - unzip
-    - wget
-    - zlib1g-dev
+  apt: 
+    pkg: [
+      'ant',
+      'cmake',
+      'curl',
+      'g++',
+      'gcc',
+      'gfortran',
+      'git-core',
+      'libffi-dev',
+      'liblapack-dev',
+      'libncurses5-dev',
+      'libopenblas-dev',
+      'libpam0g-dev',
+      'libpq-dev',
+      'libsparsehash-dev',
+      'make',
+      'mercurial',
+      'nginx-extras',
+      'openssh-server',
+      'patch',
+      'pkg-config',
+      'python-boto',
+      'python-dev',
+      'python-prettytable',
+      'python-psycopg2',
+      'python-virtualenv',
+      'python-pip',
+      'rsync',
+      'samtools',
+      'slurm-drmaa-dev',
+      'supervisor',
+      'swig',
+      'sysstat',
+      'unzip',
+      'wget',
+      'zlib1g-dev'
+    ]
+    state: "{{ apt_package_state }}"
+    install_recommends: no
 
 - name: Install packages for system maintenance
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - atop
-    - bioperl
-    - ipython
-    - iotop
-    - htop
-    - iftop
-    - nmon
-    - axel
-    - vim
+  apt: 
+    pkg: [
+      'atop',
+      'bioperl',
+      'ipython',
+      'iotop',
+      'htop',
+      'iftop',
+      'nmon',
+      'axel',
+      'vim'
+    ]
+    state: "{{ apt_package_state }}"
   when: install_maintainance_packages
 
 - name: Install required system packages - release_specific
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - postgresql-9.3
-    - postgresql-client-9.3
-    - postgresql-plpython-9.3
-    - postgresql-server-dev-9.3
+  apt:
+    pkg: [
+      'postgresql-9.3',
+      'postgresql-client-9.3',
+      'postgresql-plpython-9.3',
+      'postgresql-server-dev-9.3'
+    ]
+    state: "{{ apt_package_state }}"
   when: ansible_distribution_version <= "15.04"
 
 - name: Install required system packages - 15.10
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - postgresql-9.4
-    - postgresql-client-9.4
-    - postgresql-plpython-9.4
-    - postgresql-server-dev-9.4
-    - virtualenv
+  apt:
+    pkg: [
+      'postgresql-9.4',
+      'postgresql-client-9.4',
+      'postgresql-plpython-9.4',
+      'postgresql-server-dev-9.4',
+      'virtualenv'
+    ]
+    state: "{{ apt_package_state }}"
   when: ansible_distribution_version == "15.10"
 
 - name: Install required system packages - 16.04
-  apt: pkg={{ item }} state={{ apt_package_state }}
-  with_items:
-    - postgresql-9.5
-    - postgresql-client-9.5
-    - postgresql-plpython-9.5
-    - postgresql-server-dev-9.5
-    - virtualenv
+  apt:
+    pkg: [
+      'postgresql-9.5',
+      'postgresql-client-9.5',
+      'postgresql-plpython-9.5',
+      'postgresql-server-dev-9.5',
+      'virtualenv'
+    ]
+    state: "{{ apt_package_state }}"
   when: ansible_distribution_version == "16.04"


### PR DESCRIPTION
Invoking "apt" only once while using a loop via squash_actions is
deprecated. Use list of items as name value instead.
(Same update as in ansible-galaxy, ddda1d5 11/8/18)

Also includes 2 minor cosmetic changes (single quotes > double quotes): done of the sake of consistency and correct syntax highlighting in vim (single quotes are not necessary in those 2 lines).