### PR TITLE
add natefoo slurm-drmaa-dev repo for Ubuntu 18.04 compatibility

### DIFF
--- a/tasks/ubuntu/packages.yml
+++ b/tasks/ubuntu/packages.yml
@@ -8,6 +8,13 @@
   copy: src=galaxyproject-nginx-pin-600 dest=/etc/apt/preferences.d/galaxyproject-nginx-pin-600
   when: ansible_distribution_version <= "16.04"
 
+- name: Add custom Galaxy PPA (used for Slurm DRMAA package in Ubuntu 18.04)
+  apt_repository: 
+    repo: ppa:natefoo/slurm-drmaa
+    state: present
+    update_cache: yes
+  when: ansible_distribution_version == "18.04"
+
 - name: Add Docker repository key (Ubuntu 14.04)
   apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D
   when: configure_docker and ansible_distribution_version == "14.04"


### PR DESCRIPTION
When attempting to use the [ansible-galaxy-os](https://github.com/galaxyproject/ansible-galaxy-os) role targeting Ubuntu 18.04, the following error is produced:
```
FAILED! => {"changed": false, "msg": "No package matching 'slurm-drmaa-dev' is available"}
```

adding the [ppa:natefoo/slurm-drmaa](https://launchpad.net/~natefoo/+archive/ubuntu/slurm-drmaa) apt repository allows the installation to continue, and for jobs to execute as expected once the installation is complete (via [GalaxyKickStart](https://github.com/ARTbio/GalaxyKickStart)).

note: slurm-drmaa-dev is also installed in the role `galaxy-extras`; as such, [a similar fix has been submitted to the  repo](https://github.com/galaxyproject/ansible-galaxy-extras/pull/230).